### PR TITLE
Update pip/setuptools by using official Python docker base image.

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:xenial
+FROM python:2
 
 EXPOSE 5000
 
@@ -6,17 +6,15 @@ RUN useradd --create-home redash
 
 # Ubuntu packages
 RUN apt-get update && apt-get install -y curl && curl https://deb.nodesource.com/setup_6.x | bash - && \
-  apt-get install -y python-pip python-dev build-essential pwgen libffi-dev sudo git-core wget \
+  apt-get install -y build-essential pwgen libffi-dev sudo git-core wget \
   nodejs \
   # Postgres client
   libpq-dev \
   # for SAML
   xmlsec1 \
   # Additional packages required for data sources:
-  libssl-dev libmysqlclient-dev freetds-dev libsasl2-dev && \
+  libssl-dev default-libmysqlclient-dev freetds-dev libsasl2-dev && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/*
-
-RUN pip install -U setuptools==23.1.0
 
 WORKDIR /app

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -5,15 +5,26 @@ EXPOSE 5000
 RUN useradd --create-home redash
 
 # Ubuntu packages
-RUN apt-get update && apt-get install -y curl && curl https://deb.nodesource.com/setup_6.x | bash - && \
-  apt-get install -y build-essential pwgen libffi-dev sudo git-core wget \
-  nodejs \
-  # Postgres client
-  libpq-dev \
-  # for SAML
-  xmlsec1 \
-  # Additional packages required for data sources:
-  libssl-dev default-libmysqlclient-dev freetds-dev libsasl2-dev && \
+RUN apt-get update && \
+  apt-get install -y curl && \
+  curl https://deb.nodesource.com/setup_6.x | bash - && \
+  apt-get install -y \
+    build-essential \
+    pwgen \
+    libffi-dev \
+    sudo \
+    git-core \
+    wget \
+    nodejs \
+    # Postgres client
+    libpq-dev \
+    # for SAML
+    xmlsec1 \
+    # Additional packages required for data sources:
+    libssl-dev \
+    default-libmysqlclient-dev \
+    freetds-dev \
+    libsasl2-dev && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
Docker image: https://hub.docker.com/_/python/

Upside: Easy switching to Python 3 down the line and more recent Python and pip/setuptools updates.