### PR TITLE
update nginx

### DIFF
--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -1,3 +1,3 @@
-FROM nginx:1.9.10
+FROM nginx:1.16.1
 
 ADD redash.conf /etc/nginx/conf.d/default.conf


### PR DESCRIPTION
This updates nginx to the latest nginx stable.
The old nginx container did still run on Debian 8 which is EOL and also includes very old SSL libs that do not allow to use TLSv1.3 with a letsencrypt config as described here:
https://gist.github.com/arikfr/64c9ff8d2f2b703d4e44fe9e45a7730e