### PR TITLE
Support longer content-disposition attachment name

### DIFF
--- a/nginx/redash.conf
+++ b/nginx/redash.conf
@@ -1,15 +1,15 @@
 upstream redash {
   server redash:5000;
 }
- 
+
 server {
   listen   80 default;
- 
+
   gzip on;
   gzip_types *;
   gzip_proxied any;
   proxy_buffer_size 8k;
- 
+
   location / {
     proxy_set_header Host $http_host;
     proxy_set_header X-Real-IP $remote_addr;

--- a/nginx/redash.conf
+++ b/nginx/redash.conf
@@ -8,6 +8,7 @@ server {
   gzip on;
   gzip_types *;
   gzip_proxied any;
+  proxy_buffer_size 8k;
  
   location / {
     proxy_set_header Host $http_host;


### PR DESCRIPTION
When downloading results (in .xls/.csv/etc formats), the content-disposition attachment name is determined by the query name, which can be long, especially when including UTF-8 characters. This results in a nginx rejecting the response from upstream and responding with a 502 to the client.